### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 
 MCP Server for using Semgrep to scan code
 
+<a href="https://glama.ai/mcp/servers/4iqti5mgde">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/4iqti5mgde/badge" alt="Semgrep Server MCP server" />
+</a>
+
 [MCP](https://modelcontextprotocol.io/) is like LSP or unix pipes but for LLMs and AI Agents and coding tools such as Cursor.
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [Semgrep MCP Server](https://glama.ai/mcp/servers/4iqti5mgde) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4iqti5mgde">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/4iqti5mgde/badge" alt="Semgrep Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.