### PR TITLE
Claim Semgrep MCP on Glama.ai

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "jaksiks", 
+    "DrewDennison",
+  ]
+}


### PR DESCRIPTION
To claim [here](https://glama.ai/mcp/servers/@semgrep/mcp/tools/semgrep_scan), we add a config that points to the maintainers. 