### PR TITLE
fix: update safe_join to fix potential path traversal

### DIFF
--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -79,14 +79,14 @@ class SemgrepScanResult(BaseModel):
 
 def safe_join(base_dir: str, untrusted_path: str) -> str:
     # Absolute, normalized path to the base directory
-    base_dir = Path(base_dir).resolve()
+    base_path = Path(base_dir).resolve()
 
     # Handle empty path, current directory, or paths with only slashes
     if not untrusted_path or untrusted_path == "." or untrusted_path.strip("/") == "":
-        return base_dir.as_posix()
+        return base_path.as_posix()
 
     # Join and normalize the untrusted path
-    full_path = base_dir / Path(untrusted_path)
+    full_path = base_path / Path(untrusted_path)
 
     # Ensure the final path doesn't escape the base directory
     if not full_path == full_path.resolve():

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -83,7 +83,7 @@ def safe_join(base_dir: str, untrusted_path: str) -> str:
 
     # Handle empty path, current directory, or paths with only slashes
     if not untrusted_path or untrusted_path == "." or untrusted_path.strip("/") == "":
-        return base_dir
+        return base_dir.as_posix()
 
     # Join and normalize the untrusted path
     full_path = base_dir / Path(untrusted_path)

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -4,8 +4,8 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import Any
 from pathlib import Path
+from typing import Any
 
 import click
 import httpx

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -92,7 +92,7 @@ def safe_join(base_dir: str, untrusted_path: str) -> str:
     if not full_path == full_path.resolve():
         raise ValueError(f"Untrusted path escapes the base directory!: {untrusted_path}")
 
-    return full_path
+    return full_path.as_posix()
 
 
 # Path validation

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -78,12 +78,25 @@ class SemgrepScanResult(BaseModel):
 
 
 def safe_join(base_dir: str, untrusted_path: str) -> str:
+    """
+    Joins a base directory with an untrusted relative path and ensures the final path
+    doesn't escape the base directory.
+
+    Args:
+        base_dir: The base directory to join the untrusted path to
+        untrusted_path: The untrusted relative path to join to the base directory
+    """
     # Absolute, normalized path to the base directory
     base_path = Path(base_dir).resolve()
 
     # Handle empty path, current directory, or paths with only slashes
     if not untrusted_path or untrusted_path == "." or untrusted_path.strip("/") == "":
         return base_path.as_posix()
+
+    # Ensure untrusted path is not absolute
+    # This is soft validation, path traversal is checked later
+    if os.path.isabs(untrusted_path):
+        raise ValueError("Untrusted path must be relative")
 
     # Join and normalize the untrusted path
     full_path = base_path / Path(untrusted_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,11 @@
 import os
 import tempfile
+import shutil
 
 import pytest
 
-from semgrep_mcp.server import safe_join
+from semgrep_mcp.server import safe_join, create_temp_files_from_code_content, CodeFile
+from semgrep_mcp.server import McpError
 
 
 def test_safe_join_valid_paths():
@@ -83,3 +85,118 @@ def test_safe_join_with_normalized_base():
     # Should still prevent traversal with normalized base
     with pytest.raises(ValueError, match="Untrusted path escapes the base directory!"):
         safe_join(base_dir, "../file.txt")
+
+
+def test_create_temp_files_from_code_content():
+    """Test that create_temp_files_from_code_content correctly creates temp files with content"""
+    # Define test code files
+    code_files = [
+        CodeFile(filename="test_file.py", content="print('Hello, world!')"),
+        CodeFile(filename="nested/path/test_file.js", content="console.log('Hello, world!');"),
+        CodeFile(filename="special chars/file with spaces.txt", content="Hello, world!"),
+    ]
+
+    # Call the function
+    temp_dir = None
+    try:
+        temp_dir = create_temp_files_from_code_content(code_files)
+
+        # Check if temp directory was created
+        assert os.path.exists(temp_dir)
+        assert os.path.isdir(temp_dir)
+
+        # Check if files were created with correct content
+        for code_file in code_files:
+            file_path = os.path.join(temp_dir, code_file.filename)
+            assert os.path.exists(file_path)
+            with open(file_path, "r") as f:
+                content = f.read()
+                assert content == code_file.content
+
+        # Check that nested directories were created
+        assert os.path.exists(os.path.join(temp_dir, "nested/path"))
+        assert os.path.exists(os.path.join(temp_dir, "special chars"))
+
+    finally:
+        # Clean up
+        if temp_dir and os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_create_temp_files_from_code_content_empty_list():
+    """Test that create_temp_files_from_code_content handles empty file list"""
+    code_files = []
+
+    temp_dir = None
+    try:
+        temp_dir = create_temp_files_from_code_content(code_files)
+
+        # Check if temp directory was created
+        assert os.path.exists(temp_dir)
+        assert os.path.isdir(temp_dir)
+
+        # Directory should be empty (except for potential system files like .DS_Store)
+        # Just check that no files were created from our empty list
+        entries = os.listdir(temp_dir)
+        assert all(
+            not os.path.isfile(os.path.join(temp_dir, entry)) or entry.startswith(".")
+            for entry in entries
+        )
+
+    finally:
+        # Clean up
+        if temp_dir and os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_create_temp_files_from_code_content_empty_filename():
+    """Test that create_temp_files_from_code_content handles empty filenames"""
+    code_files = [
+        CodeFile(filename="", content="This content should be skipped"),
+        CodeFile(filename="valid_file.txt", content="This is valid content"),
+    ]
+
+    temp_dir = None
+    try:
+        temp_dir = create_temp_files_from_code_content(code_files)
+
+        # Check if temp directory was created
+        assert os.path.exists(temp_dir)
+        assert os.path.isdir(temp_dir)
+
+        # The empty filename should be skipped - we can't directly check for a file with empty name
+        # because os.path.join(temp_dir, "") just returns temp_dir
+        # Instead, we'll check that only the valid file exists in the directory
+        files = [
+            f
+            for f in os.listdir(temp_dir)
+            if os.path.isfile(os.path.join(temp_dir, f)) and not f.startswith(".")
+        ]
+        assert len(files) == 1
+        assert "valid_file.txt" in files
+
+        # The valid file should be created
+        valid_file_path = os.path.join(temp_dir, "valid_file.txt")
+        assert os.path.exists(valid_file_path)
+        with open(valid_file_path, "r") as f:
+            content = f.read()
+            assert content == "This is valid content"
+
+    finally:
+        # Clean up
+        if temp_dir and os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_create_temp_files_from_code_content_path_traversal():
+    """Test that create_temp_files_from_code_content prevents path traversal"""
+    # Define test code files with path traversal attempts
+    code_files = [
+        CodeFile(filename="../attempt_to_write_outside.txt", content="This should fail"),
+        CodeFile(filename="subdir/../../../etc/passwd", content="This should fail too"),
+        CodeFile(filename="/absolute/path/file.txt", content="This should fail as well"),
+    ]
+
+    # The function should raise a ValueError for path traversal attempts
+    with pytest.raises(McpError):
+        create_temp_files_from_code_content(code_files)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,11 +1,10 @@
 import os
-import tempfile
 import shutil
+import tempfile
 
 import pytest
 
-from semgrep_mcp.server import safe_join, create_temp_files_from_code_content, CodeFile
-from semgrep_mcp.server import McpError
+from semgrep_mcp.server import CodeFile, McpError, create_temp_files_from_code_content, safe_join
 
 
 def test_safe_join_valid_paths():
@@ -109,7 +108,7 @@ def test_create_temp_files_from_code_content():
         for code_file in code_files:
             file_path = os.path.join(temp_dir, code_file.filename)
             assert os.path.exists(file_path)
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 content = f.read()
                 assert content == code_file.content
 
@@ -178,7 +177,7 @@ def test_create_temp_files_from_code_content_empty_filename():
         # The valid file should be created
         valid_file_path = os.path.join(temp_dir, "valid_file.txt")
         assert os.path.exists(valid_file_path)
-        with open(valid_file_path, "r") as f:
+        with open(valid_file_path) as f:
             content = f.read()
             assert content == "This is valid content"
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 import pytest
 
@@ -7,26 +8,24 @@ from semgrep_mcp.server import safe_join
 
 def test_safe_join_valid_paths():
     """Test safe_join with valid paths that should be allowed"""
-    base_dir = "/tmp/test"
+    base_dir = tempfile.mkdtemp(prefix="semgrep_scan_")
 
     # Test basic path joining
-    assert safe_join(base_dir, "file.txt") == os.path.join("/tmp/test", "file.txt")
+    assert safe_join(base_dir, "file.txt") == os.path.realpath(os.path.join(base_dir, "file.txt"))
 
     # Test with subdirectories
-    assert safe_join(base_dir, "subdir/file.txt") == os.path.join("/tmp/test", "subdir/file.txt")
+    assert safe_join(base_dir, "subdir/file.txt") == os.path.realpath(os.path.join(base_dir, "subdir/file.txt"))
 
     # Test with current directory references
-    assert safe_join(base_dir, "./file.txt") == os.path.join("/tmp/test", "file.txt")
+    assert safe_join(base_dir, "./file.txt") == os.path.realpath(os.path.join(base_dir, "file.txt"))
 
     # Test with multiple subdirectories
-    assert safe_join(base_dir, "sub1/sub2/file.txt") == os.path.join(
-        "/tmp/test", "sub1/sub2/file.txt"
-    )
+    assert safe_join(base_dir, "sub1/sub2/file.txt") == os.path.realpath(os.path.join(base_dir, "sub1/sub2/file.txt"))
 
 
 def test_safe_join_path_traversal_attempts():
     """Test safe_join blocks path traversal attempts"""
-    base_dir = "/tmp/test"
+    base_dir = tempfile.mkdtemp(prefix="semgrep_scan_")
 
     # Test simple parent directory traversal
     with pytest.raises(ValueError, match="Untrusted path escapes the base directory!"):
@@ -47,33 +46,33 @@ def test_safe_join_path_traversal_attempts():
 
 def test_safe_join_edge_cases():
     """Test safe_join with edge cases"""
-    base_dir = "/tmp/test"
+    base_dir = tempfile.mkdtemp(prefix="semgrep_scan_")
 
     # Test empty path
-    assert safe_join(base_dir, "") == "/tmp/test"
+    assert safe_join(base_dir, "") == os.path.realpath(base_dir)
 
     # Test current directory
-    assert safe_join(base_dir, ".") == "/tmp/test"
+    assert safe_join(base_dir, ".") == os.path.realpath(base_dir)
 
     # Test path with only slashes
-    assert safe_join(base_dir, "///") == "/tmp/test"
+    assert safe_join(base_dir, "///") == os.path.realpath(base_dir)
 
     # Test path with spaces and special characters
-    assert safe_join(base_dir, "my file with spaces.txt") == os.path.join(
-        "/tmp/test", "my file with spaces.txt"
-    )
+    assert safe_join(base_dir, "my file with spaces.txt") == os.path.realpath(os.path.join(
+        base_dir, "my file with spaces.txt"
+    ))
 
     # Test path with unicode characters
-    assert safe_join(base_dir, "üñîçødé_fïlé.txt") == os.path.join("/tmp/test", "üñîçødé_fïlé.txt")
+    assert safe_join(base_dir, "üñîçødé_fïlé.txt") == os.path.realpath(os.path.join(base_dir, "üñîçødé_fïlé.txt"))
 
 
 def test_safe_join_with_normalized_base():
     """Test safe_join handles base directory normalization correctly"""
     # Test with non-normalized base path
-    base_dir = "/tmp/test/./subdir/../"
+    base_dir = tempfile.mkdtemp(prefix="semgrep_scan_")
 
     # Should normalize the base path
-    assert safe_join(base_dir, "file.txt") == os.path.join("/tmp/test", "file.txt")
+    assert safe_join(base_dir, "file.txt") == os.path.realpath(os.path.join(base_dir, "file.txt"))
 
     # Should still prevent traversal with normalized base
     with pytest.raises(ValueError, match="Untrusted path escapes the base directory!"):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,7 +40,7 @@ def test_safe_join_path_traversal_attempts():
         safe_join(base_dir, "subdir/../../file.txt")
 
     # Test absolute path attempt
-    with pytest.raises(ValueError, match="Untrusted path escapes the base directory!"):
+    with pytest.raises(ValueError, match="Untrusted path must be relative"):
         safe_join(base_dir, "/etc/passwd")
 
     # Test complex traversal with current directory references

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,13 +14,17 @@ def test_safe_join_valid_paths():
     assert safe_join(base_dir, "file.txt") == os.path.realpath(os.path.join(base_dir, "file.txt"))
 
     # Test with subdirectories
-    assert safe_join(base_dir, "subdir/file.txt") == os.path.realpath(os.path.join(base_dir, "subdir/file.txt"))
+    assert safe_join(base_dir, "subdir/file.txt") == os.path.realpath(
+        os.path.join(base_dir, "subdir/file.txt")
+    )
 
     # Test with current directory references
     assert safe_join(base_dir, "./file.txt") == os.path.realpath(os.path.join(base_dir, "file.txt"))
 
     # Test with multiple subdirectories
-    assert safe_join(base_dir, "sub1/sub2/file.txt") == os.path.realpath(os.path.join(base_dir, "sub1/sub2/file.txt"))
+    assert safe_join(base_dir, "sub1/sub2/file.txt") == os.path.realpath(
+        os.path.join(base_dir, "sub1/sub2/file.txt")
+    )
 
 
 def test_safe_join_path_traversal_attempts():
@@ -58,12 +62,14 @@ def test_safe_join_edge_cases():
     assert safe_join(base_dir, "///") == os.path.realpath(base_dir)
 
     # Test path with spaces and special characters
-    assert safe_join(base_dir, "my file with spaces.txt") == os.path.realpath(os.path.join(
-        base_dir, "my file with spaces.txt"
-    ))
+    assert safe_join(base_dir, "my file with spaces.txt") == os.path.realpath(
+        os.path.join(base_dir, "my file with spaces.txt")
+    )
 
     # Test path with unicode characters
-    assert safe_join(base_dir, "üñîçødé_fïlé.txt") == os.path.realpath(os.path.join(base_dir, "üñîçødé_fïlé.txt"))
+    assert safe_join(base_dir, "üñîçødé_fïlé.txt") == os.path.realpath(
+        os.path.join(base_dir, "üñîçødé_fïlé.txt")
+    )
 
 
 def test_safe_join_with_normalized_base():


### PR DESCRIPTION
### TL;DR

Improved path handling in the Semgrep MCP server by using `pathlib.Path` and enforcing relative paths for code files.

### What changed?

- Refactored `safe_join` function to use `pathlib.Path` for more robust path handling
- Removed the `common_base_dir` function as it's no longer needed
- Modified `validate_absolute_path` to use `Path.resolve()`
- Updated `create_temp_files_from_code_content` to simplify file path handling
- Added validation to ensure code files use relative paths only
- Fixed path traversal vulnerability detection

### How to test?

- Run the existing test suite which has been updated to use temporary directories
- Try submitting code files with absolute paths and verify they're rejected
- Test with various path formats including those with special characters and Unicode

### Why make this change?

This change improves security by:
1. Using the more robust `pathlib` library for path operations
2. Enforcing that all code file paths must be relative, preventing potential path traversal attacks
3. Simplifying the path handling logic to reduce the risk of security vulnerabilities

The tests were also updated to use real temporary directories instead of hardcoded paths, making them more reliable across different environments.