### PR TITLE
fix: Update models with optional fields

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -71,13 +71,9 @@ def update_chart_yaml(file_path: Path, new_version: str) -> None:
     """Update version in Chart.yaml."""
     content = file_path.read_text()
     # Update version: ...
-    new_content = re.sub(
-        r'version:\s*[\d.]+', f'version: {new_version}', content
-    )
+    new_content = re.sub(r"version:\s*[\d.]+", f"version: {new_version}", content)
     # Update appVersion: ...
-    new_content = re.sub(
-        r'appVersion:\s*"[^"]*"', f'appVersion: "{new_version}"', new_content
-    )
+    new_content = re.sub(r'appVersion:\s*"[^"]*"', f'appVersion: "{new_version}"', new_content)
     file_path.write_text(new_content)
 
 

--- a/src/semgrep_mcp/models.py
+++ b/src/semgrep_mcp/models.py
@@ -35,7 +35,7 @@ class ExternalTicket(BaseModel):
 
 class ReviewComment(BaseModel):
     external_discussion_id: str
-    external_note_id: int
+    external_note_id: int | None = None
 
 
 class Repository(BaseModel):
@@ -89,10 +89,10 @@ class Component(BaseModel):
 
 
 class Assistant(BaseModel):
-    autofix: Autofix
-    guidance: Guidance
-    autotriage: Autotriage
-    component: Component
+    autofix: Autofix | None = None
+    guidance: Guidance | None = None
+    autotriage: Autotriage | None = None
+    component: Component | None = None
 
 
 class Finding(BaseModel):

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -970,13 +970,12 @@ async def get_semgrep_rule_yaml(rule_id: str = RULE_ID_FIELD) -> str:
             ErrorData(code=INTERNAL_ERROR, message=f"Error loading Semgrep rule schema: {e!s}")
         ) from e
 
+
 @mcp.custom_route("/health", methods=["GET"])
 async def health(request: Request) -> JSONResponse:
     """Health check endpoint"""
-    return JSONResponse({
-        "status": "ok",
-        "version": __version__
-    })
+    return JSONResponse({"status": "ok", "version": __version__})
+
 
 # ---------------------------------------------------------------------------------
 # MCP Server Entry Point


### PR DESCRIPTION
### TL;DR

Made fields in Assistant model optional and fixed the external_note_id field to accept null values.

### What changed?

- Modified the `Assistant` model to make all fields optional by adding default values of `None`
- Changed the `external_note_id` field in `ReviewComment` to accept either `int` or `None`
- Reformatted code in `bump_version.py` and `server.py` to improve readability and maintain consistent style

### How to test?

1. Verify that API requests with partially populated Assistant objects are properly accepted
2. Confirm that ReviewComment objects with null external_note_id values are handled correctly
3. Run the application to ensure the health endpoint still functions properly

### Why make this change?

These changes improve flexibility in the data model by making certain fields optional, which allows for partial data to be provided in API requests. This is particularly important for the Assistant model where not all components may be needed in every context. The change to ReviewComment addresses cases where an external note ID might not be available.