### PR TITLE
Initial implementation for local scans

### DIFF
--- a/src/semgrep_mcp/models.py
+++ b/src/semgrep_mcp/models.py
@@ -4,6 +4,9 @@ from typing import Any
 from pydantic import BaseModel, Field, HttpUrl
 
 
+class LocalCodeFile(BaseModel):
+    path: str = Field(description="Absolute path to be scanned locally by Semgrep.")
+
 class CodeFile(BaseModel):
     filename: str = Field(description="Relative path to the code file")
     content: str = Field(description="Content of the code file")


### PR DESCRIPTION
This commit adds a semgrep_scan_local tool that accepts absolute paths to local directories. This should be explicitly enabled through an environment variable to prevent attacks when running on a server

Fixes #52 