### PR TITLE
feat: hook server up to `semgrep mcp`

### DIFF
--- a/src/semgrep_mcp/semgrep.py
+++ b/src/semgrep_mcp/semgrep.py
@@ -1,0 +1,215 @@
+import asyncio
+import json
+import os
+import subprocess
+from typing import Any
+
+from mcp.shared.exceptions import McpError
+from mcp.types import INTERNAL_ERROR, ErrorData
+
+################################################################################
+# Prelude #
+################################################################################
+# Communicating with the Semgrep binary.
+
+################################################################################
+# Constants #
+################################################################################
+
+_semgrep_lock = asyncio.Lock()
+
+# Global variable to store the semgrep executable path
+semgrep_executable: str | None = None
+
+################################################################################
+# Finding Semgrep #
+################################################################################
+
+
+# Semgrep utilities
+def find_semgrep_path() -> str | None:
+    """
+    Dynamically find semgrep in PATH or common installation directories
+    Returns: Path to semgrep executable or None if not found
+    """
+    # Common paths where semgrep might be installed
+    common_paths = [
+        "semgrep",  # Default PATH
+        "/usr/local/bin/semgrep",
+        "/usr/bin/semgrep",
+        "/opt/homebrew/bin/semgrep",  # Homebrew on macOS
+        "/opt/semgrep/bin/semgrep",
+        "/home/linuxbrew/.linuxbrew/bin/semgrep",  # Homebrew on Linux
+        "/snap/bin/semgrep",  # Snap on Linux
+    ]
+
+    # Add Windows paths if on Windows
+    if os.name == "nt":
+        app_data = os.environ.get("APPDATA", "")
+        if app_data:
+            common_paths.extend(
+                [
+                    os.path.join(app_data, "Python", "Scripts", "semgrep.exe"),
+                    os.path.join(app_data, "npm", "semgrep.cmd"),
+                ]
+            )
+
+    # Try each path
+    for semgrep_path in common_paths:
+        # For 'semgrep' (without path), check if it's in PATH
+        if semgrep_path == "semgrep":
+            try:
+                subprocess.run(
+                    [semgrep_path, "--version"], check=True, capture_output=True, text=True
+                )
+                return semgrep_path
+            except (subprocess.SubprocessError, FileNotFoundError):
+                continue
+
+        # For absolute paths, check if the file exists before testing
+        if os.path.isabs(semgrep_path):
+            if not os.path.exists(semgrep_path):
+                continue
+
+            # Try executing semgrep at this path
+            try:
+                subprocess.run(
+                    [semgrep_path, "--version"], check=True, capture_output=True, text=True
+                )
+                return semgrep_path
+            except (subprocess.SubprocessError, FileNotFoundError):
+                continue
+
+    return None
+
+
+async def ensure_semgrep_available() -> str:
+    """
+    Ensures semgrep is available and sets the global path in a thread-safe manner
+
+    Returns:
+        Path to semgrep executable
+
+    Raises:
+        McpError: If semgrep is not installed or not found
+    """
+    global semgrep_executable
+
+    # Fast path - check if we already have the path
+    if semgrep_executable:
+        return semgrep_executable
+
+    # Slow path - acquire lock and find semgrep
+    async with _semgrep_lock:
+        # Try to find semgrep
+        semgrep_path = find_semgrep_path()
+
+        if not semgrep_path:
+            raise McpError(
+                ErrorData(
+                    code=INTERNAL_ERROR,
+                    message="Semgrep is not installed or not in your PATH. "
+                    "Please install Semgrep manually before using this tool. "
+                    "Installation options: "
+                    "pip install semgrep, "
+                    "macOS: brew install semgrep, "
+                    "Or refer to https://semgrep.dev/docs/getting-started/",
+                )
+            )
+
+        # Store the path for future use
+        semgrep_executable = semgrep_path
+        return semgrep_path
+
+
+def set_semgrep_executable(semgrep_path: str) -> None:
+    global semgrep_executable
+    semgrep_executable = semgrep_path
+
+
+################################################################################
+# Communicating with Semgrep over RPC #
+################################################################################
+
+
+class SemgrepContext:
+    process: asyncio.subprocess.Process
+    stdin: asyncio.StreamWriter
+    stdout: asyncio.StreamReader
+
+    def __init__(self, process: asyncio.subprocess.Process) -> None:
+        self.process = process
+
+        if process.stdin is not None and process.stdout is not None:
+            self.stdin = process.stdin
+            self.stdout = process.stdout
+        else:
+            raise McpError(
+                ErrorData(
+                    code=INTERNAL_ERROR,
+                    message="Semgrep process stdin/stdout not available",
+                )
+            )
+
+    async def communicate(self, line: str) -> str:
+        self.stdin.write(f"{line}\n".encode())
+        await self.stdin.drain()
+
+        stdout = await self.stdout.readline()
+        return stdout.decode()
+
+    async def send_request(self, request: str, **kwargs: Any) -> str:
+        payload = {"method": request, **kwargs}
+
+        return await self.communicate(json.dumps(payload))
+
+
+################################################################################
+# Running Semgrep #
+################################################################################
+
+
+async def run_semgrep_process(args: list[str]) -> asyncio.subprocess.Process:
+    """
+    Runs semgrep with the given arguments as a subprocess, without waiting for it to finish.
+    """
+
+    # Ensure semgrep is available
+    semgrep_path = await ensure_semgrep_available()
+
+    # Execute semgrep command
+    process = await asyncio.create_subprocess_exec(
+        semgrep_path,
+        *args,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    return process
+
+
+async def run_semgrep(args: list[str]) -> str:
+    """
+    Runs semgrep with the given arguments
+
+    Args:
+        args: List of command arguments
+
+    Returns:
+        Output of semgrep command
+    """
+
+    process = await run_semgrep_process(args)
+
+    stdout, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        raise McpError(
+            ErrorData(
+                code=INTERNAL_ERROR,
+                message=f"Error running semgrep: ({process.returncode}) {stderr.decode()}",
+            )
+        )
+
+    return stdout.decode()

--- a/src/semgrep_mcp/semgrep.py
+++ b/src/semgrep_mcp/semgrep.py
@@ -16,10 +16,10 @@ from mcp.types import INTERNAL_ERROR, ErrorData
 # Constants #
 ################################################################################
 
-_semgrep_lock = asyncio.Lock()
+_SEMGREP_LOCK = asyncio.Lock()
 
 # Global variable to store the semgrep executable path
-semgrep_executable: str | None = None
+SEMGREP_EXECUTABLE: str | None = None
 
 ################################################################################
 # Finding Semgrep #
@@ -93,14 +93,14 @@ async def ensure_semgrep_available() -> str:
     Raises:
         McpError: If semgrep is not installed or not found
     """
-    global semgrep_executable
+    global SEMGREP_EXECUTABLE
 
     # Fast path - check if we already have the path
-    if semgrep_executable:
-        return semgrep_executable
+    if SEMGREP_EXECUTABLE:
+        return SEMGREP_EXECUTABLE
 
     # Slow path - acquire lock and find semgrep
-    async with _semgrep_lock:
+    async with _SEMGREP_LOCK:
         # Try to find semgrep
         semgrep_path = find_semgrep_path()
 
@@ -118,13 +118,13 @@ async def ensure_semgrep_available() -> str:
             )
 
         # Store the path for future use
-        semgrep_executable = semgrep_path
+        SEMGREP_EXECUTABLE = semgrep_path
         return semgrep_path
 
 
 def set_semgrep_executable(semgrep_path: str) -> None:
-    global semgrep_executable
-    semgrep_executable = semgrep_path
+    global SEMGREP_EXECUTABLE
+    SEMGREP_EXECUTABLE = semgrep_path
 
 
 ################################################################################

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -279,7 +279,8 @@ def remove_temp_dir_from_results(results: SemgrepScanResult, temp_dir: str) -> N
 async def server_lifespan(_server: Server) -> AsyncIterator[SemgrepContext]:
     """Manage server startup and shutdown lifecycle."""
     # Initialize resources on startup
-    process = await run_semgrep_process(["mcp"])
+    # MCP requires Pro Engine
+    process = await run_semgrep_process(["mcp", "--pro"])
 
     try:
         yield SemgrepContext(process=process)

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
-import asyncio
 import os
 import shutil
-import subprocess
 import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
 import click
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.server.lowlevel import Server
 from mcp.shared.exceptions import McpError
 from mcp.types import (
     INTERNAL_ERROR,
@@ -21,6 +22,12 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from semgrep_mcp.models import CodeFile, Finding, LocalCodeFile, SemgrepScanResult
+from semgrep_mcp.semgrep import (
+    SemgrepContext,
+    run_semgrep,
+    run_semgrep_process,
+    set_semgrep_executable,
+)
 
 # ---------------------------------------------------------------------------------
 # Constants
@@ -52,13 +59,8 @@ RULE_ID_FIELD = Field(description="Semgrep rule ID")
 # Global Variables
 # ---------------------------------------------------------------------------------
 
-# Global variable to store the semgrep executable path
-semgrep_executable: str | None = None
-_semgrep_lock = asyncio.Lock()
-
 # Global variable to cache deployment slug
 DEPLOYMENT_SLUG: str | None = None
-
 
 # ---------------------------------------------------------------------------------
 # Utilities
@@ -129,102 +131,6 @@ def validate_config(config: str | None = None) -> str:
         return config or ""
     # Otherwise, treat as path and validate
     return validate_absolute_path(config, "config")
-
-
-# Semgrep utilities
-def find_semgrep_path() -> str | None:
-    """
-    Dynamically find semgrep in PATH or common installation directories
-    Returns: Path to semgrep executable or None if not found
-    """
-    # Common paths where semgrep might be installed
-    common_paths = [
-        "semgrep",  # Default PATH
-        "/usr/local/bin/semgrep",
-        "/usr/bin/semgrep",
-        "/opt/homebrew/bin/semgrep",  # Homebrew on macOS
-        "/opt/semgrep/bin/semgrep",
-        "/home/linuxbrew/.linuxbrew/bin/semgrep",  # Homebrew on Linux
-        "/snap/bin/semgrep",  # Snap on Linux
-    ]
-
-    # Add Windows paths if on Windows
-    if os.name == "nt":
-        app_data = os.environ.get("APPDATA", "")
-        if app_data:
-            common_paths.extend(
-                [
-                    os.path.join(app_data, "Python", "Scripts", "semgrep.exe"),
-                    os.path.join(app_data, "npm", "semgrep.cmd"),
-                ]
-            )
-
-    # Try each path
-    for semgrep_path in common_paths:
-        # For 'semgrep' (without path), check if it's in PATH
-        if semgrep_path == "semgrep":
-            try:
-                subprocess.run(
-                    [semgrep_path, "--version"], check=True, capture_output=True, text=True
-                )
-                return semgrep_path
-            except (subprocess.SubprocessError, FileNotFoundError):
-                continue
-
-        # For absolute paths, check if the file exists before testing
-        if os.path.isabs(semgrep_path):
-            if not os.path.exists(semgrep_path):
-                continue
-
-            # Try executing semgrep at this path
-            try:
-                subprocess.run(
-                    [semgrep_path, "--version"], check=True, capture_output=True, text=True
-                )
-                return semgrep_path
-            except (subprocess.SubprocessError, FileNotFoundError):
-                continue
-
-    return None
-
-
-async def ensure_semgrep_available() -> str:
-    """
-    Ensures semgrep is available and sets the global path in a thread-safe manner
-
-    Returns:
-        Path to semgrep executable
-
-    Raises:
-        McpError: If semgrep is not installed or not found
-    """
-    global semgrep_executable
-
-    # Fast path - check if we already have the path
-    if semgrep_executable:
-        return semgrep_executable
-
-    # Slow path - acquire lock and find semgrep
-    async with _semgrep_lock:
-        # Try to find semgrep
-        semgrep_path = find_semgrep_path()
-
-        if not semgrep_path:
-            raise McpError(
-                ErrorData(
-                    code=INTERNAL_ERROR,
-                    message="Semgrep is not installed or not in your PATH. "
-                    "Please install Semgrep manually before using this tool. "
-                    "Installation options: "
-                    "pip install semgrep, "
-                    "macOS: brew install semgrep, "
-                    "Or refer to https://semgrep.dev/docs/getting-started/",
-                )
-            )
-
-        # Store the path for future use
-        semgrep_executable = semgrep_path
-        return semgrep_path
 
 
 # Utility functions for handling code content
@@ -334,38 +240,6 @@ def validate_code_files(code_files: list[CodeFile]) -> None:
             )
 
 
-async def run_semgrep(args: list[str]) -> str:
-    """
-    Runs semgrep with the given arguments
-
-    Args:
-        args: List of command arguments
-
-    Returns:
-        Output of semgrep command
-    """
-
-    # Ensure semgrep is available
-    semgrep_path = await ensure_semgrep_available()
-
-    # Execute semgrep command
-    process = await asyncio.create_subprocess_exec(
-        semgrep_path, *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-    )
-
-    stdout, stderr = await process.communicate()
-
-    if process.returncode != 0:
-        raise McpError(
-            ErrorData(
-                code=INTERNAL_ERROR,
-                message=f"Error running semgrep: ({process.returncode}) {stderr.decode()}",
-            )
-        )
-
-    return stdout.decode()
-
-
 def remove_temp_dir_from_results(results: SemgrepScanResult, temp_dir: str) -> None:
     """
     Clean the results from semgrep by converting temporary file paths back to
@@ -400,6 +274,23 @@ def remove_temp_dir_from_results(results: SemgrepScanResult, temp_dir: str) -> N
 # MCP Server
 # ---------------------------------------------------------------------------------
 
+
+@asynccontextmanager
+async def server_lifespan(_server: Server) -> AsyncIterator[SemgrepContext]:
+    """Manage server startup and shutdown lifecycle."""
+    # Initialize resources on startup
+    process = await run_semgrep_process(["mcp"])
+
+    try:
+        yield SemgrepContext(process=process)
+    finally:
+        if process.returncode is None:
+            # Clean up on shutdown
+            process.terminate()
+        else:
+            print(f"`semgrep mcp` process exited with code {process.returncode} already")
+
+
 # Create a fast MCP server
 mcp = FastMCP(
     "Semgrep",
@@ -407,6 +298,7 @@ mcp = FastMCP(
     request_timeout=DEFAULT_TIMEOUT,
     stateless_http=True,
     json_response=True,
+    lifespan=server_lifespan,
 )
 
 http_client = httpx.AsyncClient()
@@ -1072,13 +964,25 @@ async def health(request: Request) -> JSONResponse:
     envvar="MCP_TRANSPORT",
     help="Transport protocol to use: stdio, streamable-http, or sse (legacy)",
 )
-def main(transport: str) -> None:
+@click.option(
+    "--semgrep-path",
+    type=click.Path(exists=True),
+    default=None,
+    envvar="SEMGREP_PATH",
+    help="Path to the Semgrep binary",
+)
+def main(transport: str, semgrep_path: str | None) -> None:
     """Entry point for the MCP server
 
     Supports stdio, streamable-http, and sse transports.
     For stdio, it will read from stdin and write to stdout.
     For streamable-http and sse, it will start an HTTP server on port 8000.
     """
+
+    # Set the executable path in case it's manually specified.
+    if semgrep_path:
+        set_semgrep_executable(semgrep_path)
+
     if transport == "stdio":
         mcp.run(transport="stdio")
     elif transport == "streamable-http":


### PR DESCRIPTION
## What:
This PR makes it so that the MCP server can communicate with a persistent `semgrep mcp` backend.

## Why:
We would like to reap the benefits from doing things a little more closely tied to the engine. For instance, it would be nice if we could cache rules, find targets, and just generally precompute a few more things in an alternate way than just invoking Semgrep from the CLI.

## How:
We used `asynccontextmanager`, as suggested in the MCP docs, to make a `semgrep mcp` instance we can just query. We isolated everything related to communicating with Semgrep into a `semgrep.py` file, as well.

## Test plan:
With the following added code:
```
@mcp.tool()
async def run_shutdown(ctx: Context) -> str:
    """
    Shuts down the Semgrep MCP server.
    """

    context: SemgrepContext = ctx.request_context.lifespan_context

    return await context.send_request("shutdown")
```

I can run this tool via an `examples` script to verify I get `Goodbye` out, which is what I programmed it to do in https://app.graphite.dev/github/pr/semgrep/semgrep-proprietary/4305/feat(mcp)-request-handling?org=semgrep.
