### PR TITLE
chore(docker): factorize semgrep version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
-    { name = "semgrep" },
     { name = "tomli" },
     { name = "tomli-w" },
 ]
@@ -1187,7 +1186,6 @@ dev = [
     { name = "pytest", specifier = ">=8.1.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "ruff", specifier = ">=0.11.4" },
-    { name = "semgrep", specifier = ">=1.122.0" },
     { name = "tomli", specifier = ">=2.0.1" },
     { name = "tomli-w", specifier = ">=1.0.0" },
 ]


### PR DESCRIPTION
## What:
This PR makes it so that our Docker build is factorized on the version of Semgrep we use.

## Why:
Previously, our base image was just a Python image with `uv`, for convenience. We allowed the version of Semgrep to be decided by the `semgrep` dependency installed by `uv`.

For our purposes, however, it's actually quite important that we give people the option of using the MCP with more recent versions of Semgrep. If our Semgrep version lags behind, we will not be able to use new features introduced by the engine-dependent `semgrep mcp`, which means people will not be able to try new features of our MCP as quickly.

## How:
This PR just makes it so our Dockerfile uses our `semgrep` Docker images as a baseline, with the particular flavor left as an argument (to be used later). My ideal is that we can establish some release-specific Docker images for `semgrep-mcp`, or at the very least, maintain a single `semgrep-mcp:develop` image which has all the latest features.

This PR pins our version of Semgrep in the MCP to `semgrep/semgrep:latest` (currently `1.128.1`), but lays the groundwork which allows us to build `semgrep-mcp` with specific versions of Semgrep.

Note that this PR removes `semgrep` as a dependency of the MCP in terms of the `uv` project. This is not strictly true, you still need `semgrep` to make the MCP work, but we will simply enforce that it must exist in the Docker images (which are how people will typically interact with the MCP).

## Future work:
It would be cool if we could use these Docker images, which `mcp-internal` depends on, to establish a `develop.mcp.semgrep.ai/develop` or something which people can optionally use to get the latest features without needing a release of Semgrep.

## Test plan:
`docker build` into `docker run -it` allows me to see that I can control the output of `semgrep --version` based on the number we install.