### PR TITLE
chore: pin version of semgrep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.12.0",
-    "semgrep>=1.122.0",
+    "semgrep==1.128.1"
 ]
 
 [project.license]

--- a/uv.lock
+++ b/uv.lock
@@ -1175,7 +1175,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=1.12.0" },
-    { name = "semgrep", specifier = ">=1.122.0" },
+    { name = "semgrep", specifier = "==1.128.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
This just pins Semgrep to `1.128.1`, the most recent, so we can prepare for our version-bumping infra for releasing the MCP server.