### PR TITLE
chore: exclude semgrep interfaces from pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,8 @@ max-complexity = 10
 packages = [
     "src/semgrep_mcp",
 ]
+
+[tool.pyright]
+exclude = [
+    "src/semgrep_mcp/semgrep_interfaces"
+]


### PR DESCRIPTION
## What:
This PR modifies the `pyproject.toml` file to exclude the `semgrep-interfaces` submodule from `pyright`.

## Why:
pre-commit doesn't pass because pyright doesn't pass in the submodule`semgrep-interfaces`.