### PR TITLE
Adding the badge because of the great Trust Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fsemgrep%2Fmcp-0098FF?style=flat-square&logo=docker&logoColor=white)](https://ghcr.io/semgrep/mcp)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-uv-24bfa5?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=semgrep&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22semgrep-mcp%22%5D%7D&quality=insiders)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-docker-24bfa5?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=semgrep&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%20%22-i%22%2C%20%22--rm%22%2C%20%22ghcr.io%2Fsemgrep%2Fmcp%22%2C%20%22-t%22%2C%20%22stdio%22%5D%7D&quality=insiders)
+[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/semgrep/mcp)](https://archestra.ai/mcp-catalog/semgrep__mcp)
 
 A Model Context Protocol (MCP) server for using [Semgrep](https://semgrep.dev) to scan code for security vulnerabilities. Secure your [vibe coding](https://semgrep.dev/blog/2025/giving-appsec-a-seat-at-the-vibe-coding-table/)! 😅
 


### PR DESCRIPTION
I'm analyzing ~1,000 MCP servers to create a "Trust Score" that highlights projects with strong implementation and community health. Your project scored exceptionally high—congratulations\! This PR adds the new badge to your README to recognize this achievement.

The badge will look like this: [\![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/semgrep/mcp)](https://archestra.ai/mcp-catalog/semgrep__mcp)