### PR TITLE
feat(docker): install semgrep pro in build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -74,6 +74,8 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           platforms: ${{ env.PLATFORMS }}
+          secrets: |
+            semgrep_app_token=${{ secrets.SEMGREP_APP_TOKEN }}
           push: ${{ github.event_name != 'pull_request' }}
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -87,7 +89,7 @@ jobs:
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}     
+          subject-digest: ${{ steps.push.outputs.digest }}
 
       - name: Generate artifact attestation (Docker Hub)
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## What:
This PR makes it so that we install Semgrep Pro in the Docker build, so that we can successfully run `semgrep mcp` in Docker-distributed images.

## Why:
Otherwise, we will not be able to access `semgrep mcp` from Docker images.

## How:
I killed the previous multi-stage Docker build, which was adding significant complexity, and preventing me from properly doing this install. 

Initially, I tried to just add a `uv run semgrep install-semgrep-pro` step, threading secrets and stuff through. Unfortunately, the boundary between the build stage and run stage were running into issues where we could not neatly access the Python interpreter from the run stage, which was resistant to numerous fixes I tried. I decided it would be simpler to just have one stage, which to my understanding is more canonical.

I also made it so the build step is now dependent upon a `SEMGREP_APP_TOKEN`, which we have in our CI processes here.

## Test plan:
I build the image locally and tried it out via my local Cursor:
```
[13:35:15] brandon@brandons-mbp-2 λ ~/mcp (brandon/install-semgrep-pro)> docker run  -p 8000:8000 --rm -it docker.io/library/semgrep-mcp-server -t sse
INFO:     Started server process [1]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     192.168.215.1:26791 - "GET /sse HTTP/1.1" 200 OK
INFO:     192.168.215.1:22100 - "POST /sse HTTP/1.1" 405 Method Not Allowed
INFO:     192.168.215.1:29979 - "GET /sse HTTP/1.1" 200 OK
INFO:     192.168.215.1:57526 - "POST /messages/?session_id=ce22b08bb36d4056a13c4026dccb0dd7 HTTP/1.1" 202 Accepted
INFO:     192.168.215.1:52558 - "POST /messages/?session_id=ce22b08bb36d4056a13c4026dccb0dd7 HTTP/1.1" 202 Accepted
INFO:     192.168.215.1:51802 - "POST /messages/?session_id=ce22b08bb36d4056a13c4026dccb0dd7 HTTP/1.1" 202 Accepted
[08/11/25 20:35:25] INFO     Processing request of type ListToolsRequest                                                  server.py:625
[06.91][WARNING]: Skipping unknown field 'pattern-inside' in rule "semgrep.avoid-db-session-commit"
[06.91][WARNING]: Skipping unknown field 'confidence' in rule "semgrep.route-usage"
INFO:     192.168.215.1:35940 - "POST /messages/?session_id=ce22b08bb36d4056a13c4026dccb0dd7 HTTP/1.1" 202 Accepted
[08/11/25 20:36:16] INFO     Processing request of type CallToolRequest                                                   server.py:625


┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 1 file tracked by git with 2196 Code rules:

  Language      Rules   Files          Origin      Rules
 ─────────────────────────────        ───────────────────
  python          897       1          Community     225
  <multilang>      43       1          Custom         78
                                       Pro_rules     637

Semgrep errors:
Semgrep skipped 0 rules
Scanned 1 files
Found 5 matches

```

It seems to work properly, whereas before we would get an error, as we did not possess a proprietary Semgrep binary in the Docker image.