### PR TITLE
feat: experiment for passing the semgrep app token to the server via auth

### DIFF
--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -406,12 +406,6 @@ http_client = httpx.AsyncClient()
 
 
 @mcp.tool()
-async def test_tool() -> str:
-    access_token = get_access_token()
-    return f"access_token: {access_token.token if access_token else None}"
-
-
-@mcp.tool()
 async def semgrep_rule_schema() -> str:
     """
     Get the schema for a Semgrep rule

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -374,7 +374,7 @@ async def server_lifespan(_server: FastMCP) -> AsyncIterator[SemgrepContext | No
     """Manage server startup and shutdown lifecycle."""
     # Initialize resources on startup with tracing
     # MCP requires Pro Engine
-    
+
     access_token = get_access_token()
     logging.info(f"access_token: {access_token.token if access_token else None}")
 

--- a/tests/integration/test_sse_client.py
+++ b/tests/integration/test_sse_client.py
@@ -26,7 +26,10 @@ def sse_server():
 
 @pytest.mark.asyncio
 async def test_sse_client_smoke(sse_server):
-    async with sse_client(f"{base_url}/sse") as (read_stream, write_stream):
+    async with sse_client(f"{base_url}/sse", headers={"Authorization": "Bearer 1234567890"}) as (
+        read_stream,
+        write_stream,
+    ):
         async with ClientSession(read_stream, write_stream) as session:
             # Initializing session...
             await session.initialize()

--- a/tests/integration/test_streamable_client.py
+++ b/tests/integration/test_streamable_client.py
@@ -24,7 +24,9 @@ def streamable_server():
 
 @pytest.mark.asyncio
 async def test_streamable_client_smoke(streamable_server):
-    async with streamablehttp_client(f"{base_url}/mcp") as (read_stream, write_stream, _):
+    async with streamablehttp_client(
+        f"{base_url}/mcp", headers={"Authorization": "Bearer 1234567890"}
+    ) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
             # Initializing session...
             await session.initialize()


### PR DESCRIPTION
## Why:

we want to streamline the way user can start using ide/mcp, so we want to host the mcp server remotely. however, the problem with hosting the server remotely is that the server can no longer access the env vars (including `SEMGREP_APP_TOKEN`) on the client's local machine. so, we need some way to pass them to the server. we also need the vars to be passed when the client initializes the connection with the server. however, currently, because `fastmcp` abstracts away a lot of the details, there is no straightforward way to access things like http headers, which we want to use to send the token over, at server-initialization time.

## What:

this PR is a hack that uses auth to pass some arbitrary token from the client to the server so that we can use it at the start of a session. i referenced the code here: https://github.com/modelcontextprotocol/python-sdk/issues/750

## Test plan:

configure `mcp.json` to look something like this:

```
"semgrep_local": {
      "type": "sse",
      "url": "http://localhost:8000/sse",
      "headers": {
        "Authorization": "Bearer 1234567890"
      }
    }
```

while running the server locally. you should see that the token gets printed out in the logs.
`INFO:root:access_token: 1234567890`