### PR TITLE
chore: add submodules during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    environment: 
+    environment:
         name: pypi
         url: https://pypi.org/p/semgrep-mcp
     permissions:
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        submodules: true
 
     - name: Set up Python
       uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0


### PR DESCRIPTION
Otherwise, installs of `semgrep-mcp` will not be able to locate the `semgrep-interfaces` submodule.
