### PR TITLE
chore: clean up semgrep folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=secret,id=semgrep_app_token,required=true,env=SEMGREP_APP_TOKEN,uid=10001,gid=10001,mode=0440 \
     uv run semgrep install-semgrep-pro
 
+# Clear out any detritus from the pro install (especially credentials)
+RUN rm -rf /home/app/.semgrep
+
 EXPOSE 8000
 
 # expose the server to the outside world otherwise it will only be accessible from inside the container


### PR DESCRIPTION
This PR makes it so we remove the junk from the `.semgrep` folder after installing, as it is populated by running `semgrep` with an app token.

## Test plan:
```
[16:39:01] brandon@brandons-mbp-2 λ ~/mcp (main)> docker run -it --entrypoint /bin/bash semgrep-mcp-server
app@f5d32ab16de8:/app$ cat ~/.semgrep/settings.yml
cat: /home/app/.semgrep/settings.yml: No such file or directory
```
After building the MCP server image