### PR TITLE
feat: one scan tool

### DIFF
--- a/src/semgrep_mcp/semgrep.py
+++ b/src/semgrep_mcp/semgrep.py
@@ -157,18 +157,21 @@ class SemgrepContext:
 
     is_hosted: bool
     pro_engine_available: bool
+    use_rpc: bool
 
     def __init__(
         self,
         top_level_span: trace.Span,
         is_hosted: bool,
         pro_engine_available: bool,
+        use_rpc: bool,
         process: asyncio.subprocess.Process | None = None,
     ) -> None:
         self.process = process
         self.top_level_span = top_level_span
         self.is_hosted = is_hosted
         self.pro_engine_available = pro_engine_available
+        self.use_rpc = use_rpc
 
         if process is None:
             self.stdin = None
@@ -265,16 +268,22 @@ async def run_semgrep(
     return process
 
 
-async def run_semgrep_daemon(top_level_span: trace.Span) -> SemgrepContext:
+async def mk_context(top_level_span: trace.Span) -> SemgrepContext:
     """
-    Runs the semgrep daemon (`semgrep mcp`) if the user has the Pro Engine installed
-    and is running the MCP server locally.
+    Runs the semgrep daemon (`semgrep mcp`) if:
+    - the user has the Pro Engine installed
+    - is running the MCP server locally
+    - the USE_SEMGREP_RPC env var is set to true
+
+    TODO: remove the "running locally" check once we have a way to
+    obtain per-user app tokens in the hosted environment
     """
     process = None
     pro_engine_available = True
 
-    resp = await run_semgrep(top_level_span, ["--pro", "--version"])
+    use_rpc = os.environ.get("USE_SEMGREP_RPC", "true").lower() == "true"
 
+    resp = await run_semgrep(top_level_span, ["--pro", "--version"])
     # wait for the command to exit so the exit code is set
     await resp.communicate()
 
@@ -286,6 +295,8 @@ async def run_semgrep_daemon(top_level_span: trace.Span) -> SemgrepContext:
             "User doesn't have the Pro Engine installed, not running `semgrep mcp` daemon..."
         )
         pro_engine_available = False
+    elif not use_rpc:
+        logging.info("USE_SEMGREP_RPC env var is false, not running `semgrep mcp` daemon...")
     elif is_hosted():
         logging.warning(
             """
@@ -294,6 +305,7 @@ async def run_semgrep_daemon(top_level_span: trace.Span) -> SemgrepContext:
             """
         )
     else:
+        logging.info("Spawning `semgrep mcp` daemon...")
         process = await run_semgrep(top_level_span, ["mcp", "--pro", "--trace"])
 
     return SemgrepContext(
@@ -301,6 +313,7 @@ async def run_semgrep_daemon(top_level_span: trace.Span) -> SemgrepContext:
         is_hosted=is_hosted(),
         pro_engine_available=pro_engine_available,
         process=process,
+        use_rpc=use_rpc,
     )
 
 

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -693,15 +693,17 @@ async def semgrep_scan(
     """
     Runs a Semgrep scan on provided code content and returns the findings in JSON format
 
-    Depending on whether `USE_SEMGREP_RPC` is set, this tool will either run a `pysemgrep`
-    CLI scan, or an RPC-based scan.
-
-    Respectively, this will cause us to return either a `SemgrepScanResult` or a `CliOutput`.
-
     Use this tool when you need to:
       - scan code files for security vulnerabilities
       - scan code files for other issues
     """
+
+    # Implementer's note:
+    # Depending on whether `USE_SEMGREP_RPC` is set, this tool will either run a `pysemgrep`
+    # CLI scan, or an RPC-based scan.
+    # Respectively, this will cause us to return either a `SemgrepScanResult` or a `CliOutput`.
+    # I put this here, in a comment, so the MCP doesn't need to be aware
+    # of these differences.
 
     validate_code_files(code_files)
 

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -711,7 +711,7 @@ async def semgrep_scan(
 
     paths = [cf.filename for cf in code_files]
 
-    if context.use_rpc:
+    if context.process is not None:
         if config is not None:
             # This should hopefully just cause the agent to call us back with
             # the correct parameters.


### PR DESCRIPTION
This combines the `semgrep_scan` and `semgrep_scan_rpc` tools into one, which dispatches dynamically based on whether the RPC is currently running.

## Test plan:
I verifiedthat the right tool was invoked when `USE_SEMGREP_RPC` was set to `false` or not.