### PR TITLE
chore: error message on using rpc when you can't

### DIFF
--- a/src/semgrep_mcp/semgrep.py
+++ b/src/semgrep_mcp/semgrep.py
@@ -217,7 +217,19 @@ class SemgrepContext:
 
         payload = {"method": request, **kwargs}
 
-        return await self.communicate(json.dumps(payload))
+        try:
+            return await self.communicate(json.dumps(payload))
+        except Exception as e:
+            # TODO: move this code out of send_request, make a proper result
+            # type and interpret at the call site
+            # this is not specific to semgrep_scan_rpc, but it is for now!!!
+            msg = f"""
+              Error sending request to semgrep (RPC server may not be running): {e}.
+              Try using `semgrep_scan` instead.
+            """
+            logging.error(msg)
+
+            raise McpError(ErrorData(code=INTERNAL_ERROR, message=msg)) from e
 
     def shutdown(self) -> None:
         if self.process is not None:


### PR DESCRIPTION
## What:
When you don't have an app token set, we will still create the process of the Semgrep daemon, but it will have erred. This stderr message gets forwarded to our logs of the server, but the MCP has no idea what happened.

THis PR makes it so we tell the MCP that the RPC server likely isn't running, so it at least knows what's up.

In the future, we should really make the daemon err out when it fails, and have the MCP middleware interpret that result.

## Test plan:
I tested both scans work when app token set, that `semgrep_scan` works when no app token, and that `semgrep_scan_rpc` returns this error message to the agent when no app token.