### PR TITLE
clean up semgrep folder (#141)

### DIFF
--- a/src/semgrep_mcp/semgrep.py
+++ b/src/semgrep_mcp/semgrep.py
@@ -157,18 +157,21 @@ class SemgrepContext:
 
     is_hosted: bool
     pro_engine_available: bool
+    use_rpc: bool
 
     def __init__(
         self,
         top_level_span: trace.Span,
         is_hosted: bool,
         pro_engine_available: bool,
+        use_rpc: bool,
         process: asyncio.subprocess.Process | None = None,
     ) -> None:
         self.process = process
         self.top_level_span = top_level_span
         self.is_hosted = is_hosted
         self.pro_engine_available = pro_engine_available
+        self.use_rpc = use_rpc
 
         if process is None:
             self.stdin = None
@@ -265,16 +268,22 @@ async def run_semgrep(
     return process
 
 
-async def run_semgrep_daemon(top_level_span: trace.Span) -> SemgrepContext:
+async def mk_context(top_level_span: trace.Span) -> SemgrepContext:
     """
-    Runs the semgrep daemon (`semgrep mcp`) if the user has the Pro Engine installed
-    and is running the MCP server locally.
+    Runs the semgrep daemon (`semgrep mcp`) if:
+    - the user has the Pro Engine installed
+    - is running the MCP server locally
+    - the USE_SEMGREP_RPC env var is set to true
+
+    TODO: remove the "running locally" check once we have a way to
+    obtain per-user app tokens in the hosted environment
     """
     process = None
     pro_engine_available = True
 
-    resp = await run_semgrep(top_level_span, ["--pro", "--version"])
+    use_rpc = os.environ.get("USE_SEMGREP_RPC", "true").lower() == "true"
 
+    resp = await run_semgrep(top_level_span, ["--pro", "--version"])
     # wait for the command to exit so the exit code is set
     await resp.communicate()
 
@@ -286,6 +295,8 @@ async def run_semgrep_daemon(top_level_span: trace.Span) -> SemgrepContext:
             "User doesn't have the Pro Engine installed, not running `semgrep mcp` daemon..."
         )
         pro_engine_available = False
+    elif not use_rpc:
+        logging.info("USE_SEMGREP_RPC env var is false, not running `semgrep mcp` daemon...")
     elif is_hosted():
         logging.warning(
             """
@@ -294,6 +305,7 @@ async def run_semgrep_daemon(top_level_span: trace.Span) -> SemgrepContext:
             """
         )
     else:
+        logging.info("Spawning `semgrep mcp` daemon...")
         process = await run_semgrep(top_level_span, ["mcp", "--pro", "--trace"])
 
     return SemgrepContext(
@@ -301,6 +313,7 @@ async def run_semgrep_daemon(top_level_span: trace.Span) -> SemgrepContext:
         is_hosted=is_hosted(),
         pro_engine_available=pro_engine_available,
         process=process,
+        use_rpc=use_rpc,
     )
 
 

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -630,6 +630,9 @@ async def semgrep_scan(
     # Validate code_files
     validate_code_files(code_files)
 
+    # Set environment variable to track weekly scans by legacy MCP
+    os.environ["SEMGREP_LEGACY_MCP"] = "true"
+
     temp_dir = None
     try:
         # Create temporary files from code content
@@ -676,6 +679,9 @@ async def semgrep_scan_rpc(
     # Validate code_files
     # TODO: could this be slow if content is big?
     validate_code_files(code_files)
+
+    # Unset the legacy MCP environment variable to avoid confusion
+    os.environ["SEMGREP_LEGACY_MCP"] = ""
 
     context: SemgrepContext = ctx.request_context.lifespan_context
 


### PR DESCRIPTION
clean up semgrep folder (#141)

feat: add metrics on whether the MCP server is hosted (#140)

* check if hosted and add to span

* store info in SemgrepContext

* dispatch SemgrepContext at the end

Bump semgrep to 1.133.0 (#144)

Co-authored-by: semgrep-ci[bot] <semgrep-ci[bot]@users.noreply.github.com>
Co-authored-by: Brandon Wu <49291449+brandonspark@users.noreply.github.com>

downgrade (#145)

optionally no rpc

set env var to track scans