### PR TITLE
chore: add env var for path

### DIFF
--- a/src/semgrep_mcp/semgrep.py
+++ b/src/semgrep_mcp/semgrep.py
@@ -26,6 +26,8 @@ _SEMGREP_LOCK = asyncio.Lock()
 # Global variable to store the semgrep executable path
 SEMGREP_EXECUTABLE: str | None = None
 
+SEMGREP_PATH = os.getenv("SEMGREP_PATH", None)
+
 ################################################################################
 # Helpers #
 ################################################################################
@@ -59,6 +61,9 @@ def find_semgrep_path() -> str | None:
         "/home/linuxbrew/.linuxbrew/bin/semgrep",  # Homebrew on Linux
         "/snap/bin/semgrep",  # Snap on Linux
     ]
+
+    if SEMGREP_PATH:
+        common_paths.append(SEMGREP_PATH)
 
     # Add Windows paths if on Windows
     if os.name == "nt":


### PR DESCRIPTION
A customer's problem is that the MCP server can't pick up where their Semgrep installation is, as it's on a remote server. This allows parameterizing the server on a custom Semgrep path.