### PR TITLE
chore(metrics): add more server-side metrics

### DIFF
--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -641,6 +641,9 @@ async def semgrep_scan_with_custom_rule(
         args = get_semgrep_scan_args(temp_dir, rule_file_path)
         output = await run_semgrep_output(top_level_span=None, args=args)
         results: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
+
+        attach_scan_metrics(get_current_span(), results, "custom")
+
         remove_temp_dir_from_results(results, temp_dir)
         return results
 


### PR DESCRIPTION
This PR adds more metrics (including semgrep version, rule config, number of findings, number of errors, and paths). The actual rules, findings, errors, and paths are not sent here because I realized it is a bit hard to make use of the information when they are attached to spans as attributes. I plan to look into where to send them.

## Test plan:

Metrics are attached to the correct spans on Datadog. All the tools that send metrics are running properly.

[`semgrep_scan_rpc`, `security_check`​, `semgrep_scan_local`​](https://app.datadoghq.com/apm/trace/20c908f92b823b119a2563c259af97e3?graphType=waterfall&shouldShowLegend=true&spanID=10222327830761691060&traceQuery=)

[`semgrep_scan_cli`​](https://app.datadoghq.com/apm/trace/f8e66b2724357e618aadd9a24c0c8be4?graphType=waterfall&shouldShowLegend=true&spanID=17169918022578051313&traceQuery=)