### PR TITLE
fix: return correct parent span in tools

### DIFF
--- a/src/semgrep_mcp/utilities/tracing.py
+++ b/src/semgrep_mcp/utilities/tracing.py
@@ -134,7 +134,7 @@ def with_span(
     tracer = trace.get_tracer(MCP_SERVICE_NAME)
 
     context = trace.set_span_in_context(parent_span)
-    with tracer.start_span(name, context=context) as span:
+    with tracer.start_as_current_span(name, context=context) as span:
         yield span
 
 


### PR DESCRIPTION
`start_span`​ starts a span without setting it as the current span, while `start_as_current_span`​ starts a span AND set it as the current span. This PR fixes the way we create a new span so we get the tool span instead of the top-level span when we call `get_current_span()` in tools.

## Test plan:

You get the tool span when you call `get_current_span`​. Also in a PR stacked on top of this one, you can see attributes attaching to the correct current span.