### PR TITLE
fix: set `SEMGREP_USER_AGENT_APPEND` for tracking weekly scans

### DIFF
--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -321,6 +321,7 @@ def remove_temp_dir_from_results(results: SemgrepScanResult, temp_dir: str) -> N
 
 # Set environment variable to track scans by MCP
 os.environ["SEMGREP_MCP"] = "true"
+os.environ["SEMGREP_USER_AGENT_APPEND"] = "(MCP)"
 
 
 @asynccontextmanager


### PR DESCRIPTION
We want to see the MCP scans differentiated from the rest [here](https://metabase.corp.semgrep.dev/question/827-backfilled-total-weekly-scans-by-agent-type). Previously, we tried to do some work [here](https://github.com/semgrep/semgrep-proprietary/pull/4522), but since the Metabase query is based on user agent and not `environment`, we actually need to set `SEMGREP_USER_AGENT_APPEND` instead of `SEMGREP_MCP`. 

This PR sets the `SEMGREP_USER_AGENT_APPEND` env var to `"(MCP)"`, similar to what SMS does [here](https://github.com/semgrep/semgrep-app/pull/14353/files).

We should probably still keep `SEMGREP_MCP` since that will make the logs of MCP scans show that the scans are for MCP.

## Test plan:
I set the env var to `"(KAT)"` as an experiment to make sure that it works, and I saw it in the results of the Metabase query.

![image.png](https://app.graphite.dev/user-attachments/assets/aaa181b4-44f6-406c-b082-1013e566e863.png)

