### PR TITLE
chore: add semgrep version to log and top-level span

### DIFF
--- a/src/semgrep_mcp/semgrep.py
+++ b/src/semgrep_mcp/semgrep.py
@@ -46,10 +46,10 @@ def is_hosted() -> bool:
 
 
 # Semgrep utilities
-def find_semgrep_path() -> str | None:
+def find_semgrep_info() -> tuple[str | None, str]:
     """
     Dynamically find semgrep in PATH or common installation directories
-    Returns: Path to semgrep executable or None if not found
+    Returns: Path to semgrep executable and version or (None, "unknown") if not found
     """
     # Common paths where semgrep might be installed
     common_paths = [
@@ -81,10 +81,10 @@ def find_semgrep_path() -> str | None:
         # For 'semgrep' (without path), check if it's in PATH
         if semgrep_path == "semgrep":
             try:
-                subprocess.run(
+                process = subprocess.run(
                     [semgrep_path, "--version"], check=True, capture_output=True, text=True
                 )
-                return semgrep_path
+                return semgrep_path, process.stdout.strip()
             except (subprocess.SubprocessError, FileNotFoundError):
                 continue
 
@@ -95,14 +95,33 @@ def find_semgrep_path() -> str | None:
 
             # Try executing semgrep at this path
             try:
-                subprocess.run(
+                process = subprocess.run(
                     [semgrep_path, "--version"], check=True, capture_output=True, text=True
                 )
-                return semgrep_path
+                return semgrep_path, process.stdout.strip()
             except (subprocess.SubprocessError, FileNotFoundError):
                 continue
 
-    return None
+    return None, "unknown"
+
+
+def find_semgrep_path() -> str | None:
+    """
+    Find the path to the semgrep executable
+
+    Returns:
+        Path to semgrep executable or None if not found
+    """
+    semgrep_path, _ = find_semgrep_info()
+    return semgrep_path
+
+
+def get_semgrep_version() -> str:
+    """
+    Get the version of the semgrep binary.
+    """
+    _, semgrep_version = find_semgrep_info()
+    return semgrep_version
 
 
 async def ensure_semgrep_available() -> str:

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -27,6 +27,7 @@ from starlette.responses import JSONResponse
 from semgrep_mcp.models import CodeFile, Finding, LocalCodeFile, SemgrepScanResult
 from semgrep_mcp.semgrep import (
     SemgrepContext,
+    get_semgrep_version,
     mk_context,
     run_semgrep_output,
     run_semgrep_via_rpc,
@@ -1183,7 +1184,9 @@ def main(transport: str, semgrep_path: str | None) -> None:
     For stdio, it will read from stdin and write to stdout.
     For streamable-http and sse, it will start an HTTP server on port 8000.
     """
-    logging.info(f"Starting Semgrep MCP server v{__version__}")
+    logging.info(
+        f"Starting Semgrep MCP server v{__version__}, Semgrep version v{get_semgrep_version()}"
+    )
 
     # Set the executable path in case it's manually specified.
     if semgrep_path:

--- a/src/semgrep_mcp/utilities/tracing.py
+++ b/src/semgrep_mcp/utilities/tracing.py
@@ -17,7 +17,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from ruamel.yaml import YAML
 
 from semgrep_mcp.models import SemgrepScanResult
-from semgrep_mcp.semgrep import SemgrepContext, is_hosted
+from semgrep_mcp.semgrep import SemgrepContext, get_semgrep_version, is_hosted
 from semgrep_mcp.semgrep_interfaces.semgrep_output_v1 import CliOutput
 from semgrep_mcp.utilities.utils import get_user_settings_file
 from semgrep_mcp.version import __version__
@@ -142,6 +142,7 @@ def start_tracing(name: str) -> Generator[trace.Span, None, None]:
         {
             SERVICE_NAME: MCP_SERVICE_NAME,
             DEPLOYMENT_ENVIRONMENT: env,
+            "metrics.semgrep_version": get_semgrep_version(),
             "metrics.mcp_version": __version__,
             "metrics.is_hosted": is_hosted(),
             "metrics.deployment_id": get_deployment_id_from_token(token),

--- a/tests/integration/test_sse_client.py
+++ b/tests/integration/test_sse_client.py
@@ -17,7 +17,7 @@ def sse_server():
     # Start the SSE server
     proc = subprocess.Popen(["python", "src/semgrep_mcp/server.py", "-t", "sse"])
     # Wait briefly to ensure the server starts
-    time.sleep(2)
+    time.sleep(5)
     yield
     # Teardown: terminate the server
     proc.terminate()


### PR DESCRIPTION
This PR adds the Semgrep version to the logs at server startup and to the top-level span.

## Test plan:
```
➜  mcp git:(katrina/semgrep-version) ✗ uv run python ./src/semgrep_mcp/server.py -t sse
INFO:root:Starting Semgrep MCP server v0.8.1, Semgrep version v1.135.0
INFO:     Started server process [15325]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
```
![image.png](https://app.graphite.dev/user-attachments/assets/14dbff6e-9d84-4778-b550-e94266aec3a1.png)

