### PR TITLE
chore: log links to traces

### DIFF
--- a/src/semgrep_mcp/utilities/tracing.py
+++ b/src/semgrep_mcp/utilities/tracing.py
@@ -166,9 +166,11 @@ def start_tracing(name: str) -> Generator[trace.Span, None, None]:
 
     with tracer.start_as_current_span(name) as span:
         trace_id = trace.format_trace_id(span.get_span_context().trace_id)
+        # Get a link to the trace in Datadog
+        link = f"(https://app.datadoghq.com/apm/trace/{trace_id})" if env != "local" else ""
 
         logging.info("Tracing initialized")
-        logging.info(f"Tracing initialized with trace ID: {trace_id}")
+        logging.info(f"Tracing initialized with trace ID: {trace_id} {link}")
 
         yield span
 


### PR DESCRIPTION
It is a bit difficult to find the traces based on their trace ID, so this PR adds a direct link to the traces to the logs.

## Test plan:

```
➜  mcp git:(katrina/semgrep-version) uv run python ./src/semgrep_mcp/server.py -t sse
INFO:root:Starting Semgrep MCP server v0.8.1, Semgrep version v1.135.0
...
INFO:root:Tracing initialized with trace ID: de2627f437e78755c089e0356b7207b9 (https://app.datadoghq.com/apm/trace/de2627f437e78755c089e0356b7207b9)
```