### PR TITLE
chore: set `SEMGREP_MCP_TRACING_DISABLED` when running pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev-dependencies = [
     "ruff>=0.11.4",
     "pytest>=8.1.1",
     "pytest-asyncio>=0.23.0",
+    "pytest-env>=1.1.0",
     "tomli>=2.0.1",
     "tomli-w>=1.0.0",
     "pre-commit>=3.0.0",
@@ -125,3 +126,6 @@ addopts = [
     "-v",
     "--tb=short",
 ]
+
+[tool.pytest_env]
+SEMGREP_MCP_DISABLE_TRACING = "true"

--- a/uv.lock
+++ b/uv.lock
@@ -782,6 +782,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-env"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/31/27f28431a16b83cab7a636dce59cf397517807d247caa38ee67d65e71ef8/pytest_env-1.1.5.tar.gz", hash = "sha256:91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf", size = 8911, upload-time = "2024-09-17T22:39:18.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/b8/87cfb16045c9d4092cfcf526135d73b88101aac83bc1adcf82dfb5fd3833/pytest_env-1.1.5-py3-none-any.whl", hash = "sha256:ce90cf8772878515c24b31cd97c7fa1f4481cd68d588419fd45f10ecaee6bc30", size = 6141, upload-time = "2024-09-17T22:39:16.942Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1169,6 +1182,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-env" },
     { name = "ruff" },
     { name = "tomli" },
     { name = "tomli-w" },
@@ -1189,6 +1203,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.0" },
     { name = "pytest", specifier = ">=8.1.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-env", specifier = ">=1.1.0" },
     { name = "ruff", specifier = ">=0.11.4" },
     { name = "tomli", specifier = ">=2.0.1" },
     { name = "tomli-w", specifier = ">=1.0.0" },


### PR DESCRIPTION
We want to avoid generating short spans during tests. This PR disables tracing when running in the test environment.

## Test plan:

Ran pytest with the trace endpoint set to semgrep-local. After the change, no traces were sent (previously, I could see them).

Verified that running outside the test environment still sends traces as expected.