### PR TITLE
chore: pass spans into other semgrep commands

### DIFF
--- a/src/semgrep_mcp/semgrep.py
+++ b/src/semgrep_mcp/semgrep.py
@@ -237,11 +237,11 @@ async def mk_context(top_level_span: trace.Span | None) -> SemgrepContext:
     )
 
 
-async def run_semgrep_output(top_level_span: trace.Span | None, args: list[str]) -> str:
+async def run_semgrep_output(context: SemgrepContext, args: list[str]) -> str:
     """
     Runs `semgrep` with the given arguments and returns the stdout.
     """
-    process = await run_semgrep_process_sync(top_level_span, args)
+    process = await run_semgrep_process_sync(context.top_level_span, args)
 
     if process.stdout is None or process.stderr is None:
         raise McpError(

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -400,7 +400,8 @@ async def get_supported_languages(ctx: Context) -> list[str]:
     args = ["show", "supported-languages", "--experimental"]
 
     # Parse output and return list of languages
-    languages = await run_semgrep_output(top_level_span=None, args=args)
+    context: SemgrepContext = ctx.request_context.lifespan_context
+    languages = await run_semgrep_output(context, args=args)
     return [lang.strip() for lang in languages.strip().split("\n") if lang.strip()]
 
 
@@ -642,7 +643,8 @@ async def semgrep_scan_with_custom_rule(
 
         # Run semgrep scan with custom rule
         args = get_semgrep_scan_args(temp_dir, rule_file_path)
-        output = await run_semgrep_output(top_level_span=None, args=args)
+        context: SemgrepContext = ctx.request_context.lifespan_context
+        output = await run_semgrep_output(context, args=args)
         results: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
 
         attach_scan_metrics(get_current_span(), results, "custom")
@@ -693,7 +695,8 @@ async def semgrep_scan_cli(
         # Create temporary files from code content
         temp_dir = create_temp_files_from_code_content(code_files)
         args = get_semgrep_scan_args(temp_dir, config)
-        output = await run_semgrep_output(top_level_span=None, args=args)
+        context: SemgrepContext = ctx.request_context.lifespan_context
+        output = await run_semgrep_output(context, args=args)
         results: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
         remove_temp_dir_from_results(results, temp_dir)
 
@@ -842,7 +845,8 @@ async def semgrep_scan_local(
         results, skipped_rules, scanned_paths, findings, errors = [], [], [], [], []
         for cf in validated_local_files:
             args = get_semgrep_scan_args(cf.path, config)
-            output = await run_semgrep_output(top_level_span=None, args=args)
+            context: SemgrepContext = ctx.request_context.lifespan_context
+            output = await run_semgrep_output(context, args=args)
             result: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
             results.append(result)
             skipped_rules.extend(result.skipped_rules)
@@ -914,7 +918,8 @@ Here are the details of the security issues found:
         # Create temporary files from code content
         temp_dir = create_temp_files_from_code_content(validated_code_files)
         args = get_semgrep_scan_args(temp_dir)
-        output = await run_semgrep_output(top_level_span=None, args=args)
+        context: SemgrepContext = ctx.request_context.lifespan_context
+        output = await run_semgrep_output(context, args=args)
         results: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
 
         attach_scan_metrics(get_current_span(), results, None)
@@ -981,7 +986,8 @@ async def get_abstract_syntax_tree(
             "--json",
             temp_file_path,
         ]
-        return await run_semgrep_output(top_level_span=None, args=args)
+        context: SemgrepContext = ctx.request_context.lifespan_context
+        return await run_semgrep_output(context, args=args)
 
     except McpError as e:
         raise e


### PR DESCRIPTION
This PR updates all tools to pass the proper context when calling Semgrep. It also changes the `run_semgrep_output`function to take a `SemgrepContext`​ parameter instead of just `top_level_span`​.

## Test plan:

Run and confirm that spans appear from the Semgrep engine, not only from `semgrep mcp`​.