### PR TITLE
chore: delete security check

### DIFF
--- a/scripts/configure_semgrep_mcp.py
+++ b/scripts/configure_semgrep_mcp.py
@@ -173,7 +173,6 @@ def _print_next_steps(verification_success: bool) -> None:
         print("4. 🔧 Try using the tools in any conversation:")
         print("   • semgrep_scan")
         print("   • semgrep_findings")
-        print("   • security_check")
         print("5. 📊 Check MCP status in Claude Code with: /mcp")
     else:
         print("1. ⚠️  Configuration may not be fully working")

--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -878,74 +878,6 @@ async def semgrep_scan_local(
 
 @mcp.tool()
 @with_tool_span()
-async def security_check(
-    ctx: Context,
-    code_files: list[dict[str, str]] = CODE_FILES_FIELD,
-) -> str:
-    """
-    Runs a fast security check on code and returns any issues found.
-
-    Use this tool when you need to:
-      - scan code for security vulnerabilities
-      - verify that code is secure
-      - double check that code is secure before committing
-      - get a second opinion on code security
-
-    If there are any issues found, you **MUST** fix them or offer to fix them and
-    explain to the user why it's important to fix.
-    If there are no issues, you can be reasonably confident that the code is secure.
-    """
-    # Validate code_files
-    validated_code_files = validate_code_files(code_files)
-
-    no_findings_message = """No security issues found in the code!"""
-    security_issues_found_message_template = """{num_issues} security issues found in the code.
-
-Here are the details of the security issues found:
-
-<security-issues>
-    {details}
-</security-issues>
-"""
-    temp_dir = None
-    try:
-        # Create temporary files from code content
-        temp_dir = create_temp_files_from_code_content(validated_code_files)
-        args = get_semgrep_scan_args(temp_dir)
-        output = await run_semgrep_output(top_level_span=None, args=args)
-        results: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
-
-        attach_scan_metrics(get_current_span(), results, None)
-
-        remove_temp_dir_from_results(results, temp_dir)
-
-        if len(results.results) > 0:
-            return security_issues_found_message_template.format(
-                num_issues=len(results.results),
-                details=results.model_dump_json(indent=2),
-            )
-        else:
-            return no_findings_message
-
-    except McpError as e:
-        raise e
-    except ValidationError as e:
-        raise McpError(
-            ErrorData(code=INTERNAL_ERROR, message=f"Error parsing semgrep output: {e!s}")
-        ) from e
-    except Exception as e:
-        raise McpError(
-            ErrorData(code=INTERNAL_ERROR, message=f"Error running semgrep scan: {e!s}")
-        ) from e
-
-    finally:
-        if temp_dir:
-            # Clean up temporary files
-            shutil.rmtree(temp_dir, ignore_errors=True)
-
-
-@mcp.tool()
-@with_tool_span()
 async def get_abstract_syntax_tree(
     ctx: Context,
     code: str = Field(description="The code to get the AST for"),
@@ -1134,7 +1066,6 @@ TOOL_DISABLE_ENV_VARS = {
     "SEMGREP_SCAN_WITH_CUSTOM_RULE_DISABLED": "semgrep_scan_with_custom_rule",
     "SEMGREP_SCAN_DISABLED": "semgrep_scan",
     "SEMGREP_SCAN_LOCAL_DISABLED": "semgrep_scan_local",
-    "SECURITY_CHECK_DISABLED": "security_check",
     "GET_ABSTRACT_SYNTAX_TREE_DISABLED": "get_abstract_syntax_tree",
 }
 


### PR DESCRIPTION
`security_check` achieves a very similar purpose to the `semgrep_scan` tool, but generally just confuses the agent (and user) because it's not clear when to use either.

Let's delete it.