### PR TITLE
feat: add prompt to setup mcp

### DIFF
--- a/src/semgrep_mcp/server.py
+++ b/src/semgrep_mcp/server.py
@@ -1095,7 +1095,6 @@ TOOL_DISABLE_ENV_VARS = {
     "SEMGREP_SCAN_WITH_CUSTOM_RULE_DISABLED": "semgrep_scan_with_custom_rule",
     "SEMGREP_SCAN_DISABLED": "semgrep_scan",
     "SEMGREP_SCAN_LOCAL_DISABLED": "semgrep_scan_local",
-    "SECURITY_CHECK_DISABLED": "security_check",
     "GET_ABSTRACT_SYNTAX_TREE_DISABLED": "get_abstract_syntax_tree",
 }
 


### PR DESCRIPTION
This PR adds a prompt to help user set up the MCP. If the user trigger the prompt using a slash command, it checks that the user is logged in and has the pro binary, and it also add a cursor rule so Semgrep will be ran every time code is generated.

## Test plan:

https://github.com/user-attachments/assets/125b4dcb-009d-473a-a083-05a3f5467c0e

