### PR TITLE
fix: point to semgrep not semgrep-proprietary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## **⚠️ The Semgrep MCP server has been moved from a standalone repo to the [main `semgrep` repository!](https://github.com/semgrep/semgrep-proprietary/tree/develop/OSS/cli/src/semgrep/mcp) ⚠️**
+## **⚠️ The Semgrep MCP server has been moved from a standalone repo to the [main `semgrep` repository!](https://github.com/semgrep/semgrep/tree/develop/cli/src/semgrep/mcp) ⚠️**
 **This repository has been deprecated, and further updates to the Semgrep MCP server will be made via the official `semgrep` binary.**
 
 <p align="center">


### PR DESCRIPTION
I mistakenly linked to `semgrep-proprietary` instead of `semgrep` in #201. So, this fixes it.